### PR TITLE
Prepend origin/ to branch, not to tag

### DIFF
--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -460,8 +460,8 @@ vcsGit =
                    ++ verboseArg
                       where loc = srpLocation
         resetArgs   = "reset" : verboseArg ++ ["--hard", resetTarget, "--" ]
-        resetBranch = fmap ("origin/" ++) srpTag
         resetTarget = fromMaybe "HEAD" (resetBranch `mplus` srpTag)
+        resetBranch = fmap ("origin/" ++) srpBranch
         verboseArg  = [ "--quiet" | verbosity < Verbosity.normal ]
 
 gitProgram :: Program


### PR DESCRIPTION
This change fixes the failing git synchronization test. This test failed, because prepending `origin/` to a commit hash, e. g. `origin/ca82a6dff817ec66f44342007202690a93763949`, does not work with git.

With this change, the synchronization now works correctly with branch names, but only when they are given in the `branch` field of `source-repository-package`, not when they are given in the `tag` field.

The way i see it, that is ok, because branch names are not intended to be used in the `tag` field, and that is why there is a `branch` field. But there is currently no documentation on these fields, so i can not be sure what the actual intended behavior is.